### PR TITLE
feat: 태그 리스트 동적으로 변경

### DIFF
--- a/app/(blog)/blog/blogPage.tsx
+++ b/app/(blog)/blog/blogPage.tsx
@@ -13,6 +13,20 @@ export default function BlogContent({ blogList }: { blogList: PostList }) {
   const router = useRouter();
   const [tag, setTag] = useState(blogList.searchTag);
   const [isLoading, setIsLoading] = useState(true);
+  const [allTags, setAllTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchTags = async () => {
+      try {
+        const response = await fetch("/api/posts?type=tags");
+        const tags = await response.json();
+        setAllTags(tags);
+      } catch (error) {
+        console.error("태그 로딩 실패:", error);
+      }
+    };
+    fetchTags();
+  }, []);
 
   useEffect(() => {
     setTag(blogList.searchTag);
@@ -37,21 +51,17 @@ export default function BlogContent({ blogList }: { blogList: PostList }) {
         <S.TapButton isTap={tag === "all"} onClick={() => handleMove("all")}>
           All
         </S.TapButton>
-        <S.TapButton isTap={tag === "front"} onClick={() => handleMove("front")}>
-          FrontEnd
-        </S.TapButton>
-        <S.TapButton isTap={tag === "back"} onClick={() => handleMove("back")}>
-          BackEnd
-        </S.TapButton>
-        <S.TapButton isTap={tag === "etc"} onClick={() => handleMove("etc")}>
-          Etc
-        </S.TapButton>
+        {allTags.map((uniqueTag) => (
+          <S.TapButton key={uniqueTag} isTap={tag === uniqueTag} onClick={() => handleMove(uniqueTag)} className="mb-2">
+            {uniqueTag}
+          </S.TapButton>
+        ))}
       </S.MenuTapBox>
 
       <Divider margin="0 0 16px 0" />
-      
+
       <S.TapTitle>
-        📚 {tagConverter(tag)} ({blogList?.totalElement})
+        📚 {tag === "all" ? "All" : tag} ({blogList?.totalElement})
       </S.TapTitle>
 
       <S.PostContainer>
@@ -60,9 +70,7 @@ export default function BlogContent({ blogList }: { blogList: PostList }) {
         ) : (blogList?.data.length || 0) > 0 ? (
           blogList?.data.map((post) => <PostBox key={post._id} post={post} />)
         ) : (
-          <div className="text-center py-12 text-gray-500">
-            {tag}에 해당하는 포스트가 없어요
-          </div>
+          <div className="text-center py-12 text-gray-500">{tag}에 해당하는 포스트가 없어요</div>
         )}
       </S.PostContainer>
     </S.ContentBox>

--- a/app/(blog)/blog/blogPage.tsx
+++ b/app/(blog)/blog/blogPage.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { PostList } from "@/types/post";
 import { Divider } from "@/components";
-import tagConverter from "@/lib/tagConverter";
 
 import PostBox from "./components/PostBox";
 import * as S from "./style";

--- a/app/(blog)/blog/components/PostBox.tsx
+++ b/app/(blog)/blog/components/PostBox.tsx
@@ -43,20 +43,12 @@ export default function PostBox({ post }: { post?: PostData }) {
         </div>
         <div className="w-full md:w-[calc(100%-230px)] h-full p-2 flex flex-col gap-2 justify-between order-2 md:order-1">
           <div className="h-full flex flex-col gap-3">
-            <h2 className="text-lg font-semibold text-gray-900 line-clamp-2 group-hover:text-green-600 transition-colors">
-              {post.title}
-            </h2>
-            <p className="text-sm text-gray-600 line-clamp-2 md:line-clamp-3">
-              {removeMd(post.content)}
-            </p>
+            <h2 className="text-lg font-semibold text-gray-900 line-clamp-2 group-hover:text-green-600 transition-colors">{post.title}</h2>
+            <p className="text-sm text-gray-600 line-clamp-2 md:line-clamp-3">{removeMd(post.content)}</p>
           </div>
           <div className="flex gap-3 items-center">
-            <span className="text-sm font-semibold text-green-600">
-              {tagConverter(post.tag)}
-            </span>
-            <span className="text-sm text-gray-500">
-              {dayjs.tz(post.createdAt).format("YYYY년 MM월 DD일")}
-            </span>
+            <span className="text-sm font-semibold text-green-600">{post.tag}</span>
+            <span className="text-sm text-gray-500">{dayjs.tz(post.createdAt).format("YYYY년 MM월 DD일")}</span>
           </div>
         </div>
       </div>

--- a/app/(blog)/blog/components/PostBox.tsx
+++ b/app/(blog)/blog/components/PostBox.tsx
@@ -8,7 +8,6 @@ import removeMd from "remove-markdown-and-html";
 import dayjs from "@/lib/dayjs";
 
 import { PostData } from "@/types/post";
-import tagConverter from "@/lib/tagConverter";
 
 export default function PostBox({ post }: { post?: PostData }) {
   return !post ? (

--- a/app/(blog)/blog/style.ts
+++ b/app/(blog)/blog/style.ts
@@ -17,11 +17,17 @@ export const ContentBox = styled.main`
 `;
 
 export const MenuTapBox = styled.div`
-  width: 100%;
-  overflow-x: auto;
   display: flex;
-  gap: 12px;
+  gap: 8px;
   padding: 8px 0;
+  overflow-x: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  flex-wrap: wrap;
+  justify-content: flex-start;
 `;
 
 export const TapButton = styled("button")<{ isTap?: boolean }>`

--- a/app/(blog)/home/components/RecentPostCard.tsx
+++ b/app/(blog)/home/components/RecentPostCard.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
 import dayjs from "@/lib/dayjs";
-import tagConverter from "@/lib/tagConverter";
 import { PostData } from "@/types/post";
 
 export default function RecentPostCard({ _id, title, tag, thumbnail, createdAt }: Omit<PostData, "content">) {

--- a/app/(blog)/home/components/RecentPostCard.tsx
+++ b/app/(blog)/home/components/RecentPostCard.tsx
@@ -4,13 +4,12 @@ import dayjs from "@/lib/dayjs";
 import tagConverter from "@/lib/tagConverter";
 import { PostData } from "@/types/post";
 
-export default function RecentPostCard({ _id, title, tag, thumbnail, createdAt }: Omit<PostData, 'content'>) {
+export default function RecentPostCard({ _id, title, tag, thumbnail, createdAt }: Omit<PostData, "content">) {
   return (
     <Link
       href={`posts/${_id}`}
       key={_id}
-      className="group bg-white w-[280px] h-[280px] rounded-xl overflow-hidden shadow-md hover:shadow-lg transition-all duration-300 flex flex-col"
-    >
+      className="group bg-white w-[280px] h-[280px] rounded-xl overflow-hidden shadow-md hover:shadow-lg transition-all duration-300 flex flex-col">
       <div className="relative">
         <div className="w-full h-[160px] overflow-hidden border border-gray-100">
           <Image
@@ -22,18 +21,14 @@ export default function RecentPostCard({ _id, title, tag, thumbnail, createdAt }
           />
         </div>
         <span className="absolute top-3 right-3 px-3 py-1 bg-white/90 backdrop-blur-sm rounded-full text-sm font-medium text-green-600 border border-green-100">
-          {tagConverter(tag, true)}
+          {tag}
         </span>
       </div>
-      
+
       <div className="p-4 flex-1 flex flex-col justify-between">
-        <h3 className="text-base font-medium text-gray-900 mb-2 line-clamp-2 group-hover:text-green-600 transition-colors">
-          {title}
-        </h3>
-        <p className="text-sm text-gray-500">
-          {dayjs.tz(createdAt).format("YYYY년 MM월 DD일")}
-        </p>
+        <h3 className="text-base font-medium text-gray-900 mb-2 line-clamp-2 group-hover:text-green-600 transition-colors">{title}</h3>
+        <p className="text-sm text-gray-500">{dayjs.tz(createdAt).format("YYYY년 MM월 DD일")}</p>
       </div>
     </Link>
   );
-} 
+}

--- a/app/(blog)/posts/[id]/components/PostContent/index.tsx
+++ b/app/(blog)/posts/[id]/components/PostContent/index.tsx
@@ -6,7 +6,6 @@ import { PostData } from "@/types/post";
 
 import { Divider } from "@/components";
 import dayjs from "@/lib/dayjs";
-import tagConverter from "@/lib/tagConverter";
 
 // Highlight.js 설정
 hljs.configure({

--- a/app/(blog)/posts/[id]/components/PostContent/index.tsx
+++ b/app/(blog)/posts/[id]/components/PostContent/index.tsx
@@ -39,7 +39,7 @@ export default function PostContent({ content }: { content: PostData }) {
       <h1>{content.title}</h1>
       <div className="flex items-center gap-3 py-3 pb-5 text-sm">
         {/* TagAndDate */}
-        <span className="text-green-600 font-semibold bg-gray-100 px-2 py-1 rounded-lg">{tagConverter(content.tag)}</span>
+        <span className="text-green-600 font-semibold bg-gray-100 px-2 py-1 rounded-lg">{content.tag}</span>
         <span className="-mt-[3px] text-gray-700">{dayjs.tz(content.createdAt).format("YYYY년 MM월 DD일")}</span>
       </div>
       <Divider height="1px" margin="8px 0 24px 0" />

--- a/app/api/posts/getPostList.ts
+++ b/app/api/posts/getPostList.ts
@@ -69,14 +69,11 @@ export async function getPostAll() {
     return NextResponse.json({ error: "서버 오류가 발생했습니다." }, { status: 500 });
   }
 }
-
 export async function getAllTags() {
   try {
-    const posts = await db
-      .collection("posts")
-      .find({}, { projection: { tag: 1 } })
-      .toArray();
-    const tags = [...new Set(posts.map((post) => post.tag))];
+    const tags = await db.collection("posts").distinct("tag");
+    // 알파벳·한글 순서 정렬로 UI 일관성 유지
+    tags.sort();
     return NextResponse.json(tags);
   } catch (e) {
     console.error(e);

--- a/app/api/posts/getPostList.ts
+++ b/app/api/posts/getPostList.ts
@@ -69,3 +69,17 @@ export async function getPostAll() {
     return NextResponse.json({ error: "서버 오류가 발생했습니다." }, { status: 500 });
   }
 }
+
+export async function getAllTags() {
+  try {
+    const posts = await db
+      .collection("posts")
+      .find({}, { projection: { tag: 1 } })
+      .toArray();
+    const tags = [...new Set(posts.map((post) => post.tag))];
+    return NextResponse.json(tags);
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ error: "서버 오류가 발생했습니다." }, { status: 500 });
+  }
+}

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -1,14 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getPostList } from "./getPostList";
+import { getPostList, getAllTags } from "./getPostList";
 
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const page = parseInt(searchParams.get("page") || "1");
-    const searchTag = searchParams.get("searchTag") || "";
+    const type = searchParams.get("type");
 
-    if (searchTag !== "front" && searchTag !== "back" && searchTag !== "" && searchTag !== "all" && searchTag !== "etc")
-      return NextResponse.json({ error: "tag값이 올바르지 않습니다." }, { status: 400 });
+    if (type === "tags") {
+      return getAllTags();
+    }
+
+    const page = parseInt(searchParams.get("page") || "1");
+    let searchTag = searchParams.get("searchTag") || "";
+
+    if (!searchTag) {
+      searchTag = "";
+    }
 
     return getPostList(page, searchTag);
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.4.0",
+    "react-to-print": "^3.1.0",
     "remove-markdown-and-html": "^0.1.0",
     "tailwindcss": "^3.4.17",
     "zustand": "^5.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6436,19 +6436,10 @@ react-markdown@~9.0.1:
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
 
-react-pdf@*:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-9.2.1.tgz#35294da1232d310243ffe5e54f39281e6c98d8d4"
-  integrity sha512-AJt0lAIkItWEZRA5d/mO+Om4nPCuTiQ0saA+qItO967DTjmGjnhmF+Bi2tL286mOTfBlF5CyLzJ35KTMaDoH+A==
-  dependencies:
-    clsx "^2.0.0"
-    dequal "^2.0.3"
-    make-cancellable-promise "^1.3.1"
-    make-event-props "^1.6.0"
-    merge-refs "^1.3.0"
-    pdfjs-dist "4.8.69"
-    tiny-invariant "^1.0.0"
-    warning "^4.0.0"
+react-to-print@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-3.1.0.tgz#70f2f3e43314ce9e71bb0a69fad47208e89c1320"
+  integrity sha512-hiJZVmJtaRm9EHoUTG2bordyeRxVSGy9oFVV7fSvzOWwctPp6jbz2R6NFkaokaTYBxC7wTM/fMV5eCXsNpEwsA==
 
 react@^19.0.0:
   version "19.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6436,6 +6436,20 @@ react-markdown@~9.0.1:
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
 
+react-pdf@*:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-9.2.1.tgz#35294da1232d310243ffe5e54f39281e6c98d8d4"
+  integrity sha512-AJt0lAIkItWEZRA5d/mO+Om4nPCuTiQ0saA+qItO967DTjmGjnhmF+Bi2tL286mOTfBlF5CyLzJ35KTMaDoH+A==
+  dependencies:
+    clsx "^2.0.0"
+    dequal "^2.0.3"
+    make-cancellable-promise "^1.3.1"
+    make-event-props "^1.6.0"
+    merge-refs "^1.3.0"
+    pdfjs-dist "4.8.69"
+    tiny-invariant "^1.0.0"
+    warning "^4.0.0"
+
 react-to-print@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-3.1.0.tgz#70f2f3e43314ce9e71bb0a69fad47208e89c1320"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 블로그 태그 목록이 API에서 동적으로 불러와져 버튼으로 표시됩니다.

- **Bug Fixes**
  - 태그명이 더 이상 변환되지 않고 원래 문자열 그대로 표시됩니다.

- **Style**
  - 태그 버튼 영역의 스크롤바가 숨겨지고, 더 나은 레이아웃과 간격으로 개선되었습니다.

- **Chores**
  - `react-to-print` 패키지가 새롭게 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->